### PR TITLE
Build restic 0.12.1 from source

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,12 +1,38 @@
+
+# https://hub.docker.com/_/golang
+FROM golang:1.17.2-alpine3.14 AS restic
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache build-base curl git
+
+WORKDIR /usr/src/app
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+# restic is available in the alpine repos and it has a self-update function
+# but we want to build from source so we can get a specific release
+# https://restic.readthedocs.io/en/v0.12.1/020_installation.html
+ARG RESTIC_RELEASE=0.12.1
+ARG RESTIC_SHA256=a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb
+
+RUN curl -fsSL -o restic.tar.gz \
+    https://github.com/restic/restic/releases/download/v${RESTIC_RELEASE}/restic-${RESTIC_RELEASE}.tar.gz && \
+    echo "${RESTIC_SHA256}  restic.tar.gz" | sha256sum -c - && \
+    tar -xzf restic.tar.gz --strip 1 && \
+    rm restic.tar.gz && \
+    go run build.go
+    
 # https://hub.docker.com/_/alpine
 FROM alpine:3.14.2
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache ca-certificates fuse openssh rclone restic bash blkid curl rsync jq tzdata
+RUN apk add --no-cache ca-certificates fuse openssh rclone bash blkid curl rsync jq tzdata
+
+COPY --from=restic /usr/src/app/restic /usr/bin/restic
+
+RUN restic version
 
 WORKDIR /usr/src/app
-
-RUN restic self-update
 
 COPY *.sh ./
 RUN chmod +x ./*.sh

--- a/app/do-backup.sh
+++ b/app/do-backup.sh
@@ -40,11 +40,11 @@ else
     info "Starting backup of ${uuid} with tags '${tags}'..."
 fi
 
-restic snapshots 1>/dev/null 2>&1 || restic init
+/usr/bin/restic snapshots 1>/dev/null 2>&1 || /usr/bin/restic init
 
 rsync -avz "${uuid}:/${DEVICE_DATA_ROOT}/" "${cache}/" --delete "${dry_run[@]}"
 # TODO: wait until this PR is in an official release https://github.com/restic/restic/pull/3300
-truthy "${DRY_RUN:-}" || restic -r "${repository}" --verbose backup "${cache}" --host "${uuid}" --tag "${tags}" "${@}" 1>/dev/stdout 2>/dev/stderr
+truthy "${DRY_RUN:-}" || /usr/bin/restic -r "${repository}" --verbose backup "${cache}" --host "${uuid}" --tag "${tags}" "${@}" 1>/dev/stdout 2>/dev/stderr
 
 if truthy "${DRY_RUN:-}"
 then

--- a/app/do-restore.sh
+++ b/app/do-restore.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # TODO: wait until this PR is in an official release https://github.com/restic/restic/pull/3300
-truthy "${DRY_RUN:-}" || restic -r "${repository}" --verbose restore latest --target "${cache}" --host "${source_uuid}" "${@}"
+truthy "${DRY_RUN:-}" || /usr/bin/restic -r "${repository}" --verbose restore latest --target "${cache}" --host "${source_uuid}" "${@}"
 rsync -avz "${cache}/" "${target_uuid}:/${DEVICE_DATA_ROOT}/" --delete "${dry_run[@]}"
 
 if truthy "${DRY_RUN:-}"

--- a/app/run.sh
+++ b/app/run.sh
@@ -38,7 +38,7 @@ source /usr/src/app/storage.sh
 
 release_lock
 
-restic unlock || true
+/usr/bin/restic unlock || true
 
 DRY_RUN=1 /usr/src/app/auto.sh || sleep infinity
 


### PR DESCRIPTION
restic is available in the alpine repos and it has a self-update function
but we want to build from source so we can get a specific release

https://restic.readthedocs.io/en/v0.12.1/020_installation.html

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>